### PR TITLE
[feat] Add support for HOST option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-mcp-server",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-mcp-server",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/inspector": "github:modelcontextprotocol/inspector",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
           "maximum": 65535,
           "description": "The port number for the MCP server"
         },
+        "vscode-mcp-server.host": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "Host address for the MCP server"
+        },
         "vscode-mcp-server.defaultEnabled": {
           "type": "boolean",
           "default": false,
@@ -48,7 +53,7 @@
               "description": "Enable file operations tools (read, write, list files)"
             },
             "edit": {
-              "type": "boolean", 
+              "type": "boolean",
               "description": "Enable file editing tools (create, edit, delete files)"
             },
             "shell": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,6 +85,7 @@ async function toggleServerState(context: vscode.ExtensionContext): Promise<void
     
     const config = vscode.workspace.getConfiguration('vscode-mcp-server');
     const port = config.get<number>('port') || 3000;
+    const host = config.get<string>('host') || '127.0.0.1';
     
     // Update status bar immediately to provide feedback
     updateStatusBar(port);
@@ -95,7 +96,7 @@ async function toggleServerState(context: vscode.ExtensionContext): Promise<void
             logger.info(`[toggleServerState] Creating MCP server instance`);
             const terminal = getExtensionTerminal(context);
             const toolConfig = getToolConfiguration();
-            mcpServer = new MCPServer(port, terminal, toolConfig);
+            mcpServer = new MCPServer(port, host, terminal, toolConfig);
             mcpServer.setFileListingCallback(async (path: string, recursive: boolean) => {
                 try {
                     return await listWorkspaceFiles(path, recursive);
@@ -155,6 +156,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const config = vscode.workspace.getConfiguration('vscode-mcp-server');
         const defaultEnabled = config.get<boolean>('defaultEnabled') ?? false;
         const port = config.get<number>('port') || 3000;
+        const host = config.get<string>('host') || '127.0.0.1';
 
         // Load saved state or use configured default
         serverEnabled = context.globalState.get('mcpServerEnabled', defaultEnabled);
@@ -176,7 +178,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             // Initialize MCP server with the configured port, terminal, and tool configuration
             const toolConfig = getToolConfiguration();
-            mcpServer = new MCPServer(port, terminal, toolConfig);
+            mcpServer = new MCPServer(port, host, terminal, toolConfig);
 
             // Set up file listing callback
             mcpServer.setFileListingCallback(async (path: string, recursive: boolean) => {
@@ -229,10 +231,11 @@ export async function activate(context: vscode.ExtensionContext) {
                     // Start new server with updated configuration
                     const config = vscode.workspace.getConfiguration('vscode-mcp-server');
                     const port = config.get<number>('port') || 3000;
+                    const host = config.get<string>('host') || '127.0.0.1';
                     const terminal = getExtensionTerminal(context);
                     const toolConfig = getToolConfiguration();
                     
-                    mcpServer = new MCPServer(port, terminal, toolConfig);
+                    mcpServer = new MCPServer(port, host, terminal, toolConfig);
                     mcpServer.setFileListingCallback(async (path: string, recursive: boolean) => {
                         try {
                             return await listWorkspaceFiles(path, recursive);

--- a/src/server.ts
+++ b/src/server.ts
@@ -233,7 +233,7 @@ export class MCPServer {
                 this.httpServer = this.app.listen(this.port, this.host, () => {
                     const httpStartTime = Date.now() - httpServerStartTime;
                     logger.info(`[MCPServer.start] HTTP Server started (took ${httpStartTime}ms)`);
-                    logger.info(`MCP Server listening on localhost:${this.port}`);
+                    logger.info(`MCP Server listening on ${this.host}:${this.port}`);
                     
                     const totalTime = Date.now() - startTime;
                     logger.info(`[MCPServer.start] Server startup complete (total: ${totalTime}ms)`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ export class MCPServer {
     private app: express.Application;
     private httpServer?: Server;
     private port: number;
+    private host: string;
     private fileListingCallback?: FileListingCallback;
     private terminal?: vscode.Terminal;
     private toolConfig: ToolConfiguration;
@@ -33,8 +34,9 @@ export class MCPServer {
         this.fileListingCallback = callback;
     }
 
-    constructor(port: number = 3000, terminal?: vscode.Terminal, toolConfig?: ToolConfiguration) {
+    constructor(port: number = 3000, host: string = '127.0.0.1', terminal?: vscode.Terminal, toolConfig?: ToolConfiguration) {
         this.port = port;
+        this.host = host;
         this.terminal = terminal;
         this.toolConfig = toolConfig || {
             file: true,
@@ -228,7 +230,7 @@ export class MCPServer {
             
             return new Promise((resolve) => {
                 // Bind to localhost only for security
-                this.httpServer = this.app.listen(this.port, '127.0.0.1', () => {
+                this.httpServer = this.app.listen(this.port, this.host, () => {
                     const httpStartTime = Date.now() - httpServerStartTime;
                     logger.info(`[MCPServer.start] HTTP Server started (took ${httpStartTime}ms)`);
                     logger.info(`MCP Server listening on localhost:${this.port}`);


### PR DESCRIPTION
<img width="1130" height="336" alt="image" src="https://github.com/user-attachments/assets/fda7ca7b-649c-4245-816b-9236a9e9068f" />

Adds an option to VSCode settings to set the host the MCP server listens on, defaults to localhost.